### PR TITLE
refactor: redirect subsequent imports of "source-map-support" to this…

### DIFF
--- a/source-map-support.d.ts
+++ b/source-map-support.d.ts
@@ -38,8 +38,9 @@ export interface Options {
     /**
      * Callback will be called every time we redirect due to `redirectConflictingLibrary`
      * This allows consumers to log helpful warnings if they choose.
+     * @param parent NodeJS.Module which made the require() or require.resolve() call
      */
-    onConflictingLibraryRedirect?: (request, parent, isMain, redirectedRequest) => void;
+    onConflictingLibraryRedirect?: (request: string, parent: any, isMain: boolean, redirectedRequest: string) => void;
 }
 
 export interface Position {

--- a/source-map-support.d.ts
+++ b/source-map-support.d.ts
@@ -31,6 +31,15 @@ export interface Options {
     overrideRetrieveSourceMap?: boolean | undefined;
     retrieveFile?(path: string): string;
     retrieveSourceMap?(source: string): UrlAndMap | null;
+    /**
+     * Set false to disable redirection of require / import `source-map-support` to `@cspotcode/source-map-support`
+     */
+    redirectConflictingLibrary?: boolean;
+    /**
+     * Callback will be called every time we redirect due to `redirectConflictingLibrary`
+     * This allows consumers to log helpful warnings if they choose.
+     */
+    onConflictingLibraryRedirect?: (request, parent, isMain, redirectedRequest) => void;
 }
 
 export interface Position {

--- a/source-map-support.js
+++ b/source-map-support.js
@@ -561,11 +561,11 @@ exports.install = function(options) {
   // Redirect subsequent imports of "source-map-support"
   // to this package
   const originalResolveFilename = Module._resolveFilename;
-  Module._resolveFilename = function resolveFilenameProxy(...args) {
-    if (args[0] === 'source-map-support') {
-      args[0] = '@cspotcode/source-map-support';
+  Module._resolveFilename = function resolveFilenameProxy(request, parent, isMain, options) {
+    if (request === 'source-map-support') {
+      request = '@cspotcode/source-map-support';
     }
-    return originalResolveFilename.call(this, ...args);
+    return originalResolveFilename.call(this, request, parent, isMain, options);
   }
 
   // Allow sources to be found by methods other than reading the files

--- a/source-map-support.js
+++ b/source-map-support.js
@@ -563,7 +563,7 @@ exports.install = function(options) {
   const originalResolveFilename = Module._resolveFilename;
   Module._resolveFilename = function resolveFilenameProxy(request, parent, isMain, options) {
     if (request === 'source-map-support') {
-      request = '@cspotcode/source-map-support';
+      request = require.resolve('@cspotcode/source-map-support');
     }
     return originalResolveFilename.call(this, request, parent, isMain, options);
   }

--- a/source-map-support.js
+++ b/source-map-support.js
@@ -555,6 +555,19 @@ exports.install = function(options) {
     }
   }
 
+  // Use dynamicRequire to avoid including in browser bundles
+  var Module = dynamicRequire(module, 'module');
+
+  // Redirect subsequent imports of "source-map-support"
+  // to this package
+  const originalRequire = Module.prototype.require;
+  Module.prototype.require = function requireProxy(id) {
+    if (id === 'source-map-support') {
+      id = '@cspotcode/source-map-support';
+    }
+    return originalRequire.call(this, id);
+  }
+
   // Allow sources to be found by methods other than reading the files
   // directly from disk.
   if (options.retrieveFile) {
@@ -577,8 +590,6 @@ exports.install = function(options) {
 
   // Support runtime transpilers that include inline source maps
   if (options.hookRequire && !isInBrowser()) {
-    // Use dynamicRequire to avoid including in browser bundles
-    var Module = dynamicRequire(module, 'module');
     var $compile = Module.prototype._compile;
 
     if (!$compile.__sourceMapSupport) {

--- a/source-map-support.js
+++ b/source-map-support.js
@@ -651,21 +651,24 @@ exports.install = function(options) {
         onConflictingLibraryRedirectArr: []
       }
       Module._resolveFilename = sharedData.moduleResolveFilenameHook.installedValue = function (request, parent, isMain, options) {
-        // Match all source-map-support entrypoints: source-map-support, source-map-support/register
-        let requestRedirect;
-        if (request === 'source-map-support') {
-          requestRedirect = './';
-        } else if (request === 'source-map-support/register') {
-          requestRedirect = './register';
-        }
+        if (sharedData.moduleResolveFilenameHook && sharedData.moduleResolveFilenameHook.enabled) {
+          // Match all source-map-support entrypoints: source-map-support, source-map-support/register
+          let requestRedirect;
+          if (request === 'source-map-support') {
+            requestRedirect = './';
+          } else if (request === 'source-map-support/register') {
+            requestRedirect = './register';
+          }
 
-        if (requestRedirect !== undefined) {
-            const newRequest = require.resolve(requestRedirect);
-            for (const cb of sharedData.moduleResolveFilenameHook.onConflictingLibraryRedirectArr) {
-              cb(request, parent, isMain, options, newRequest);
-            }
-            request = newRequest;
+          if (requestRedirect !== undefined) {
+              const newRequest = require.resolve(requestRedirect);
+              for (const cb of sharedData.moduleResolveFilenameHook.onConflictingLibraryRedirectArr) {
+                cb(request, parent, isMain, options, newRequest);
+              }
+              request = newRequest;
+          }
         }
+        
         return originalValue.call(this, request, parent, isMain, options);
       }
     } 

--- a/source-map-support.js
+++ b/source-map-support.js
@@ -560,12 +560,12 @@ exports.install = function(options) {
 
   // Redirect subsequent imports of "source-map-support"
   // to this package
-  const originalRequire = Module.prototype.require;
-  Module.prototype.require = function requireProxy(id) {
-    if (id === 'source-map-support') {
-      id = '@cspotcode/source-map-support';
+  const originalResolveFilename = Module._resolveFilename;
+  Module._resolveFilename = function resolveFilenameProxy(...args) {
+    if (args[0] === 'source-map-support') {
+      args[0] = '@cspotcode/source-map-support';
     }
-    return originalRequire.call(this, id);
+    return originalResolveFilename.call(this, ...args);
   }
 
   // Allow sources to be found by methods other than reading the files

--- a/test.js
+++ b/test.js
@@ -730,10 +730,11 @@ describe('redirects require() of "source-map-support" to this module', function(
     assert.strictEqual(onConflictingLibraryRedirectCalls.length, 1);
     assert.strictEqual(onConflictingLibraryRedirectCalls2.length, 1);
     for(const args of [onConflictingLibraryRedirectCalls[0], onConflictingLibraryRedirectCalls2[0]]) {
-      const [request, parent, isMain, redirectedRequest] = args;
+      const [request, parent, isMain, options, redirectedRequest] = args;
       assert.strictEqual(request, 'source-map-support');
       assert.strictEqual(parent, module);
       assert.strictEqual(isMain, false);
+      assert.strictEqual(options, undefined);
       assert.strictEqual(redirectedRequest, require.resolve('.'));
     }
   });


### PR DESCRIPTION
… package

Fixes: https://github.com/TypeStrong/ts-node/issues/1441

EDIT from @cspotcode: blocked by #28 because I think we'll need to be sure the shared state also tracks installation of the redirections in this ticket