### PR TITLE
Add @cspotcode/source-map-support/register-hook-require

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ From here you have two options.
 
 ```bash
 node -r @cspotcode/source-map-support/register compiled.js
+# Or to enable hookRequire
+node -r @cspotcode/source-map-support/register-hook-require compiled.js
 ```
 
 ##### Programmatic Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cspotcode/source-map-support",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cspotcode/source-map-support",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-consumer": "0.8.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cspotcode/source-map-support",
   "description": "Fixes stack traces for files with source maps",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": "./source-map-support.js",
   "types": "./source-map-support.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "files": [
     "/register.d.ts",
     "/register.js",
+    "/register-hook-require.d.ts",
+    "/register-hook-require.js",
     "/source-map-support.d.ts",
     "/source-map-support.js"
   ],

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/evanw/node-source-map-support"
+    "url": "https://github.com/cspotcode/node-source-map-support"
   },
   "bugs": {
-    "url": "https://github.com/evanw/node-source-map-support/issues"
+    "url": "https://github.com/cspotcode/node-source-map-support/issues"
   },
   "license": "MIT",
   "engines": {

--- a/register-hook-require.d.ts
+++ b/register-hook-require.d.ts
@@ -1,7 +1,7 @@
 // tslint:disable:no-useless-files
 
 // For following usage:
-//    import '@cspotcode/source-map-support/register'
+//    import '@cspotcode/source-map-support/register-hook-require'
 // Instead of:
 //    import sourceMapSupport from '@cspotcode/source-map-support'
-//    sourceMapSupport.install()
+//    sourceMapSupport.install({hookRequire: true})

--- a/register-hook-require.js
+++ b/register-hook-require.js
@@ -1,0 +1,3 @@
+require('./').install({
+    hookRequire: true
+});


### PR DESCRIPTION
Adds `--require` entrypoint which sets `hookRequire: true`

Implements evanw/node-source-map-support/pull/239
evanw/node-source-map-support/pull/257