### PR TITLE
Amendment to #23: redirect subsequent imports of "source-map-support" to this package

### DIFF
--- a/source-map-support.d.ts
+++ b/source-map-support.d.ts
@@ -39,8 +39,9 @@ export interface Options {
      * Callback will be called every time we redirect due to `redirectConflictingLibrary`
      * This allows consumers to log helpful warnings if they choose.
      * @param parent NodeJS.Module which made the require() or require.resolve() call
+     * @param options options object internally passed to node's `_resolveFilename` hook
      */
-    onConflictingLibraryRedirect?: (request: string, parent: any, isMain: boolean, redirectedRequest: string) => void;
+    onConflictingLibraryRedirect?: (request: string, parent: any, isMain: boolean, options: any, redirectedRequest: string) => void;
 }
 
 export interface Position {

--- a/source-map-support.js
+++ b/source-map-support.js
@@ -35,6 +35,11 @@ function dynamicRequire(mod, request) {
 // Increment this if the format of sharedData changes in a breaking way.
 var sharedDataVersion = 1;
 
+/**
+ * @template T
+ * @param {T} defaults
+ * @returns {T}
+ */
 function initializeSharedData(defaults) {
   var sharedDataKey = 'source-map-support/sharedData';
   if (typeof Symbol !== 'undefined') {
@@ -80,7 +85,7 @@ var sharedData = initializeSharedData({
   /** @type {HookState} */
   moduleResolveFilenameHook: undefined,
 
-  /** @type {Array<(request: string, parent: any, isMain: boolean, redirectedRequest: string) => void>} */
+  /** @type {Array<(request: string, parent: any, isMain: boolean, options: any, redirectedRequest: string) => void>} */
   onConflictingLibraryRedirectArr: [],
 
   // If true, the caches are reset before a stack trace formatting operation


### PR DESCRIPTION
Amending #23
Discovered when implementing TypeStrong/ts-node#1496

I could write tests but this class of problem is caught by typechecking, so I'm inclined to rely on that and hopefully enabled checkJs for this library eventually.