### PR TITLE
fix bug where errors without a message would still have colon in "Error: "

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -662,7 +662,7 @@ function createPrepareStackTrace(hookState) {
     } else {
       var name = error.name || 'Error';
       var message = error.message || '';
-      errorString = name + ": " + message;
+      errorString = message ? name + ": " + message : name;
     }
 
     var state = { nextPosition: null, curPosition: null };


### PR DESCRIPTION
Found while working on https://github.com/facebook/jest/pull/12786