### PR TITLE
Fix for "this" being undefined

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -46,18 +46,26 @@ function initializeSharedData(defaults) {
   if (typeof Symbol !== 'undefined') {
     sharedDataKey = Symbol.for(sharedDataKey);
   }
-  var sharedData = this[sharedDataKey];
-  if (!sharedData) {
-    sharedData = { version: sharedDataVersion };
-    if (Object.defineProperty) {
-      Object.defineProperty(this, sharedDataKey, { value: sharedData });
+
+  var sharedData = { version: sharedDataVersion }
+
+  if (this !== undefined) {
+    var data = this[sharedDataKey];
+    if (!data) {
+      if (Object.defineProperty) {
+        Object.defineProperty(this, sharedDataKey, { value: sharedData });
+      } else {
+        this[sharedDataKey] = sharedData;
+      }
     } else {
-      this[sharedDataKey] = sharedData;
+      sharedData = data;
+    }
+    
+    if (sharedDataVersion !== sharedData.version) {
+      throw new Error("Multiple incompatible instances of source-map-support were loaded");
     }
   }
-  if (sharedDataVersion !== sharedData.version) {
-    throw new Error("Multiple incompatible instances of source-map-support were loaded");
-  }
+  
   for (var key in defaults) {
     if (!(key in sharedData)) {
       sharedData[key] = defaults[key];


### PR DESCRIPTION
Fixing an issue where "this" could end up being undefined for some reason in WDIO.

Here is the error trace I am consistently receiving:
```
2022-06-15T03:58:16.658Z ERROR @wdio/local-runner: Failed launching test session: Error: Couldn't initialise "@wdio/cucumber-framework".
TypeError: Cannot read property 'Symbol(source-map-support/sharedData)' of undefined
    at initializeSharedData (/Users/yexe017/Projects/OH/gcom-react-order-history/test/end-to-end/node_modules/@cucumber/cucumber/node_modules/@cspotcode/source-map-support/source-map-support.js:49:20)
    at Object.<anonymous> (/Users/yexe017/Projects/OH/gcom-react-order-history/test/end-to-end/node_modules/@cucumber/cucumber/node_modules/@cspotcode/source-map-support/source-map-support.js:78:18)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Module._compile (/Users/yexe017/Projects/OH/gcom-react-order-history/test/end-to-end/node_modules/pirates/lib/index.js:136:24)
    at Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at require.extensions.<computed> (/Users/yexe017/Projects/OH/gcom-react-order-history/test/end-to-end/node_modules/ts-node/src/index.ts:1445:43)
    at Object.newLoader [as .js] (/Users/yexe017/Projects/OH/gcom-react-order-history/test/end-to-end/node_modules/pirates/lib/index.js:141:7)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at safeRequire (/Users/yexe017/Projects/OH/gcom-react-order-history/test/end-to-end/node_modules/@wdio/utils/build/utils.js:192:15)
    at initialisePlugin (/Users/yexe017/Projects/OH/gcom-react-order-history/test/end-to-end/node_modules/@wdio/utils/build/initialisePlugin.js:30:50)
    at Runner.run (/Users/yexe017/Projects/OH/gcom-react-order-history/test/end-to-end/node_modules/@wdio/runner/build/index.js:82:56)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

Here is the package.config for the project in question:
```
{
  "scripts": {
    "check-types": "tsc",
    "clean": "read -p \"Are you sure you want to clean the project? [y/n] \" REPLY; if [[ $REPLY =~ ^[Yy]$ ]]; then rm -R .git .github .codeclimate.yml .travis.yml wdio.BUILD.conf.js src/features/**; fi",
    "test": "run-s test:*",
    "test:lint": "eslint 'src/**/*.ts'",
    "format": "npx prettier --write .",
    "test:features": "wdio run wdio.BUILD.conf.ts",
    "wdio:mock": "wdio run wdio.MOCK.conf.ts",
    "wdio:dev": "wdio run wdio.DEV.conf.ts",
    "wdio:qa": "wdio run wdio.QA.conf.ts",
    "wdio:prod": "wdio run wdio.PROD.conf.ts",
    "wdio": "wdio run wdio.conf.js"
  },
  "devDependencies": {
    "@babel/cli": "^7.16.8",
    "@babel/core": "^7.16.12",
    "@babel/plugin-proposal-export-default-from": "^7.16.7",
    "@babel/preset-env": "^7.16.11",
    "@babel/preset-typescript": "^7.16.7",
    "@babel/register": "^7.16.9",
    "@typescript-eslint/eslint-plugin": "^5.10.1",
    "@typescript-eslint/parser": "^5.10.1",
    "@typescript-eslint/types": "^5.10.1",
    "@wdio/cli": "^7.20.2",
    "@wdio/config": "^7.20.1",
    "@wdio/cucumber-framework": "^7.20.2",
    "@wdio/local-runner": "^7.20.2",
    "@wdio/sauce-service": "^7.20.2",
    "@wdio/selenium-standalone-service": "^7.20.1",
    "@wdio/spec-reporter": "^7.20.0",
    "@wdio/static-server-service": "^7.20.0",
    "@wdio/types": "^7.20.0",
    "chromedriver": "^101.0.0",
    "eslint": "^8.7.0",
    "eslint-config-prettier": "^8.3.0",
    "eslint-plugin-import": "^2.25.4",
    "eslint-plugin-wdio": "^7.4.2",
    "http-server": "^14.1.0",
    "node-fetch": "^2.6.1",
    "ts-node": "^10.4.0",
    "typescript": "^4.5.5",
    "wdio-chromedriver-service": "^7.3.2",
    "webdriverio": "^7.16.13"
  }
}
```